### PR TITLE
Refactor method names for clarity and consistency

### DIFF
--- a/Sources/AnimatedImageCore/AnimatedImageProvider.swift
+++ b/Sources/AnimatedImageCore/AnimatedImageProvider.swift
@@ -81,7 +81,7 @@ public final class AnimatedImageProvider: Sendable {
     }
 
     func index(for targetTimestamp: TimeInterval) -> Int? {
-        timingCalculator.calculateFrameIndex(
+        timingCalculator.frameIndex(
             for: targetTimestamp,
             indices: indices,
             delayTime: delayTime

--- a/Sources/AnimatedImageCore/Processors/AnimationTimingCalculator.swift
+++ b/Sources/AnimatedImageCore/Processors/AnimationTimingCalculator.swift
@@ -11,7 +11,7 @@ public struct AnimationTimingCalculator: Sendable {
     ///   - indices: 表示フレームのインデックス配列
     ///   - delayTime: フレーム間の時間間隔
     /// - Returns: 対応するフレームインデックス（存在しない場合はnil）
-    public func calculateFrameIndex(
+    public func frameIndex(
         for targetTimestamp: TimeInterval,
         indices: [Int],
         delayTime: Double
@@ -35,7 +35,7 @@ public struct AnimationTimingCalculator: Sendable {
     ///   - indices: 表示フレームのインデックス配列
     ///   - delayTime: フレーム間の時間間隔
     /// - Returns: 総継続時間（秒）
-    public func calculateTotalDuration(
+    public func totalDuration(
         indices: [Int],
         delayTime: Double
     ) -> TimeInterval {
@@ -49,12 +49,12 @@ public struct AnimationTimingCalculator: Sendable {
     ///   - indices: 表示フレームのインデックス配列
     ///   - delayTime: フレーム間の時間間隔
     /// - Returns: 進行率（0.0〜1.0）
-    public func calculateAnimationProgress(
+    public func animationProgress(
         at currentTime: TimeInterval,
         indices: [Int],
         delayTime: Double
     ) -> Double {
-        let totalDuration = calculateTotalDuration(indices: indices, delayTime: delayTime)
+        let totalDuration = totalDuration(indices: indices, delayTime: delayTime)
         guard totalDuration > 0 else { return 0 }
 
         let normalizedTime = currentTime.truncatingRemainder(dividingBy: totalDuration)

--- a/Sources/AnimatedImageCore/Processors/CGImageProcessor.swift
+++ b/Sources/AnimatedImageCore/Processors/CGImageProcessor.swift
@@ -18,18 +18,18 @@ public actor CGImageProcessor: Sendable {
         )
         
         let newSize = aspectFitSize(
-            for: originalSize,
-            maxSize: constrainedSize
+            of: originalSize,
+            in: constrainedSize
         )
         .applying(CGAffineTransform(scaleX: scale, y: scale))
         
-        if originalSize.isLessThanOrEqualTo(newSize) && usePreparingForDisplay {
+        if originalSize.isLessThanOrEqual(to: newSize) && usePreparingForDisplay {
             return image
         }
         return resize(image: image, newSize: newSize, interpolationQuality: interpolationQuality)
     }
     
-    func aspectFitSize(for currentSize: Size, maxSize: Size) -> Size {
+    func aspectFitSize(of currentSize: Size, in maxSize: Size) -> Size {
         let aspectWidth = CGFloat(maxSize.width) / CGFloat(currentSize.width)
         let aspectHeight = CGFloat(maxSize.height) / CGFloat(currentSize.height)
         let scalingFactor = min(aspectWidth, aspectHeight)

--- a/Sources/AnimatedImageCore/Processors/ImageProcessor.swift
+++ b/Sources/AnimatedImageCore/Processors/ImageProcessor.swift
@@ -57,9 +57,9 @@ public struct ImageProcessor: Sendable {
         let imageCount = autoreleasepool { image.imageCount }
         guard !Task.isCancelled else { return nil }
 
-        let optimizedSize = calculateOptimizedSize(renderSize: renderSize)
-        let frameConfiguration = calculateFrameConfiguration(
-            imageSize: optimizedSize,
+        let optimizedSize = optimizedSize(for: renderSize)
+        let frameConfiguration = frameConfiguration(
+            for: optimizedSize,
             imageCount: imageCount,
             scale: scale,
             image: image
@@ -79,13 +79,13 @@ public struct ImageProcessor: Sendable {
     }
 
     /// 最適化されたサイズを計算
-    public func calculateOptimizedSize(renderSize: Size) -> Size {
+    public func optimizedSize(for renderSize: Size) -> Size {
         min(configuration.maxSize, renderSize)
     }
 
     /// フレーム設定を計算
-    public func calculateFrameConfiguration(
-        imageSize: Size,
+    public func frameConfiguration(
+        for imageSize: Size,
         imageCount: Int,
         scale: CGFloat,
         image: any AnimatedImage

--- a/Sources/AnimatedImageCore/Utilities/Size.swift
+++ b/Sources/AnimatedImageCore/Utilities/Size.swift
@@ -38,7 +38,7 @@ extension Size {
 
 // MARK: - 比較演算
 extension Size {
-    public func isLessThanOrEqualTo(_ size: Size) -> Bool {
+    public func isLessThanOrEqual(to size: Size) -> Bool {
         width <= size.width && height <= size.height
     }
     

--- a/Tests/AnimatedImageTests/Processors/AnimationTimingCalculatorTests.swift
+++ b/Tests/AnimatedImageTests/Processors/AnimationTimingCalculatorTests.swift
@@ -1,6 +1,6 @@
 import Testing
 
-@testable import AnimatedImage
+@testable import AnimatedImageCore
 
 @Suite("AnimationTimingCalculator テスト")
 struct AnimationTimingCalculatorTests {
@@ -12,7 +12,7 @@ struct AnimationTimingCalculatorTests {
         let delayTime = 0.1
 
         // 最初のフレーム
-        let firstIndex = calculator.calculateFrameIndex(
+        let firstIndex = calculator.frameIndex(
             for: 0.0,
             indices: indices,
             delayTime: delayTime
@@ -20,7 +20,7 @@ struct AnimationTimingCalculatorTests {
         #expect(firstIndex == 0)
 
         // 中間のフレーム
-        let middleIndex = calculator.calculateFrameIndex(
+        let middleIndex = calculator.frameIndex(
             for: 0.25,
             indices: indices,
             delayTime: delayTime
@@ -28,7 +28,7 @@ struct AnimationTimingCalculatorTests {
         #expect(middleIndex != nil)
 
         // 最後のフレーム付近
-        let lastIndex = calculator.calculateFrameIndex(
+        let lastIndex = calculator.frameIndex(
             for: 0.45,
             indices: indices,
             delayTime: delayTime
@@ -42,7 +42,7 @@ struct AnimationTimingCalculatorTests {
 
         let indices = [0, 1, 2, 3, 4]
         let delayTime = 0.1
-        let duration = calculator.calculateTotalDuration(indices: indices, delayTime: delayTime)
+        let duration = calculator.totalDuration(indices: indices, delayTime: delayTime)
 
         #expect(duration == 0.5)  // 5フレーム × 0.1秒
     }
@@ -54,7 +54,7 @@ struct AnimationTimingCalculatorTests {
         let delayTime = 0.25
 
         // 開始時点
-        let startProgress = calculator.calculateAnimationProgress(
+        let startProgress = calculator.animationProgress(
             at: 0.0,
             indices: indices,
             delayTime: delayTime
@@ -62,7 +62,7 @@ struct AnimationTimingCalculatorTests {
         #expect(startProgress == 0.0)
 
         // 中間時点
-        let middleProgress = calculator.calculateAnimationProgress(
+        let middleProgress = calculator.animationProgress(
             at: 0.5,
             indices: indices,
             delayTime: delayTime
@@ -70,7 +70,7 @@ struct AnimationTimingCalculatorTests {
         #expect(middleProgress == 0.5)
 
         // 終了時点
-        let endProgress = calculator.calculateAnimationProgress(
+        let endProgress = calculator.animationProgress(
             at: 1.0,
             indices: indices,
             delayTime: delayTime
@@ -83,7 +83,7 @@ struct AnimationTimingCalculatorTests {
         let calculator = AnimationTimingCalculator()
 
         // 空のインデックス配列
-        let emptyIndex = calculator.calculateFrameIndex(
+        let emptyIndex = calculator.frameIndex(
             for: 1.0,
             indices: [],
             delayTime: 0.1
@@ -91,7 +91,7 @@ struct AnimationTimingCalculatorTests {
         #expect(emptyIndex == nil)
 
         // delayTimeが0
-        let zeroDelayIndex = calculator.calculateFrameIndex(
+        let zeroDelayIndex = calculator.frameIndex(
             for: 1.0,
             indices: [0, 1],
             delayTime: 0.0
@@ -99,7 +99,7 @@ struct AnimationTimingCalculatorTests {
         #expect(zeroDelayIndex == nil)
 
         // 空配列での継続時間
-        let emptyDuration = calculator.calculateTotalDuration(indices: [], delayTime: 0.1)
+        let emptyDuration = calculator.totalDuration(indices: [], delayTime: 0.1)
         #expect(emptyDuration == 0.0)
     }
 
@@ -110,7 +110,7 @@ struct AnimationTimingCalculatorTests {
         let delayTime = 0.01
 
         // 複数周期後の計算
-        let longTimeIndex = calculator.calculateFrameIndex(
+        let longTimeIndex = calculator.frameIndex(
             for: 5.5,  // 5.5秒後
             indices: indices,
             delayTime: delayTime

--- a/Tests/AnimatedImageTests/Processors/CGImageProcessorTests.swift
+++ b/Tests/AnimatedImageTests/Processors/CGImageProcessorTests.swift
@@ -14,7 +14,7 @@ struct CGImageProcessorTests {
         // 元サイズより小さくフィット
         let currentSize = Size(width: 200, height: 100)
         let maxSize = Size(width: 100, height: 100)
-        let fitSize = await processor.aspectFitSize(for: currentSize, maxSize: maxSize)
+        let fitSize = await processor.aspectFitSize(of: currentSize, in: maxSize)
         
         #expect(fitSize.width == 100)
         #expect(fitSize.height == 50)
@@ -22,7 +22,7 @@ struct CGImageProcessorTests {
         // 正方形の画像を長方形にフィット
         let squareSize = Size(width: 100, height: 100)
         let rectMaxSize = Size(width: 200, height: 100)
-        let squareFitSize = await processor.aspectFitSize(for: squareSize, maxSize: rectMaxSize)
+        let squareFitSize = await processor.aspectFitSize(of: squareSize, in: rectMaxSize)
         
         #expect(squareFitSize.width == 100)
         #expect(squareFitSize.height == 100)

--- a/Tests/AnimatedImageTests/Processors/ImageProcessorTests.swift
+++ b/Tests/AnimatedImageTests/Processors/ImageProcessorTests.swift
@@ -17,7 +17,7 @@ struct ImageProcessorTests {
         #expect(processor.isValidRenderSize(renderSize))
         #expect(!processor.isValidRenderSize(.zero))
 
-        let optimizedSize = processor.calculateOptimizedSize(renderSize: renderSize)
+        let optimizedSize = processor.optimizedSize(for: renderSize)
         #expect(optimizedSize.width <= configuration.maxSize.width)
         #expect(optimizedSize.height <= configuration.maxSize.height)
     }
@@ -28,8 +28,8 @@ struct ImageProcessorTests {
         let processor = ImageProcessor(configuration: configuration)
 
         let mockImage = MockAnimatedImage(frameCount: 10, delayTime: 0.1)
-        let frameConfig = processor.calculateFrameConfiguration(
-            imageSize: Size(width: 100, height: 100),
+        let frameConfig = processor.frameConfiguration(
+            for: Size(width: 100, height: 100),
             imageCount: 10,
             scale: 1,
             image: mockImage

--- a/Tests/AnimatedImageTests/Utilities/CGSizeTests.swift
+++ b/Tests/AnimatedImageTests/Utilities/CGSizeTests.swift
@@ -9,10 +9,10 @@ struct SizeTests {
     func isLessThanEqual() async throws {
         let size = Size(width: 100, height: 100)
         let otherSize1 = Size(width: 100, height: 100)
-        #expect(size.isLessThanOrEqualTo(otherSize1) == true)
+        #expect(size.isLessThanOrEqual(to: otherSize1) == true)
         let otherSize2 = Size(width: 10, height: 10)
-        #expect(size.isLessThanOrEqualTo(otherSize2) == false)
+        #expect(size.isLessThanOrEqual(to: otherSize2) == false)
         let otherSize3 = Size(width: 200, height: 200)
-        #expect(size.isLessThanOrEqualTo(otherSize3) == true)
+        #expect(size.isLessThanOrEqual(to: otherSize3) == true)
     }
 }


### PR DESCRIPTION
Renamed several methods across core and test files to improve clarity and consistency, such as changing 'calculateFrameIndex' to 'frameIndex', 'calculateTotalDuration' to 'totalDuration', and 'isLessThanOrEqualTo' to 'isLessThanOrEqual(to:)'. Updated all usages in related classes and tests to match the new method names.