### PR TITLE
frame delay handling with FrameDurationProcessor

### DIFF
--- a/Sources/AnimatedImageCore/Images/APNGImage.swift
+++ b/Sources/AnimatedImageCore/Images/APNGImage.swift
@@ -21,8 +21,12 @@ public final class APNGImage: AnimatedImage, Sendable {
         let imageProperty =
             CGImageSourceCopyPropertiesAtIndex(source, index, nil) as? [CFString: Any]
         let frameProperty = imageProperty?[kCGImagePropertyPNGDictionary] as? [CFString: Any]
-        let delayTime = frameProperty?[kCGImagePropertyAPNGDelayTime] as? Double
-        return delayTime ?? 0.1
+        let frameDurationProcessor = FrameDurationProcessor()
+        let delayTime = frameDurationProcessor.process(
+            unclampedDelayTime: { frameProperty?[kCGImagePropertyAPNGUnclampedDelayTime] as? Double },
+            delayTime: { frameProperty?[kCGImagePropertyAPNGDelayTime] as? Double }
+        )
+        return delayTime
     }
 
     public nonisolated func image(at index: Int) -> CGImage? {

--- a/Sources/AnimatedImageCore/Images/GifImage.swift
+++ b/Sources/AnimatedImageCore/Images/GifImage.swift
@@ -18,11 +18,14 @@ public final class GifImage: AnimatedImage, Sendable {
 
     public nonisolated func delayTime(at index: Int) -> Double {
         guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return 0.1 }
-        let imageProperty =
-            CGImageSourceCopyPropertiesAtIndex(source, index, nil) as? [CFString: Any]
+        let imageProperty = CGImageSourceCopyPropertiesAtIndex(source, index, nil) as? [CFString: Any]
         let frameProperty = imageProperty?[kCGImagePropertyGIFDictionary] as? [CFString: Any]
-        let delayTime = frameProperty?[kCGImagePropertyGIFDelayTime] as? Double
-        return delayTime ?? 0.1
+        let frameDurationProcessor = FrameDurationProcessor()
+        let delayTime = frameDurationProcessor.process(
+            unclampedDelayTime: { frameProperty?[kCGImagePropertyGIFUnclampedDelayTime] as? Double },
+            delayTime: { frameProperty?[kCGImagePropertyGIFDelayTime] as? Double }
+        )
+        return delayTime
     }
 
     public nonisolated func image(at index: Int) -> CGImage? {

--- a/Sources/AnimatedImageCore/Images/WebPImage.swift
+++ b/Sources/AnimatedImageCore/Images/WebPImage.swift
@@ -18,20 +18,14 @@ public final class WebPImage: AnimatedImage, Sendable {
 
     public nonisolated func delayTime(at index: Int) -> Double {
         guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return 0.1 }
-        let imageProperty =
-            CGImageSourceCopyPropertiesAtIndex(source, index, nil) as? [CFString: Any]
+        let imageProperty = CGImageSourceCopyPropertiesAtIndex(source, index, nil) as? [CFString: Any]
         let frameProperty = imageProperty?[kCGImagePropertyWebPDictionary] as? [CFString: Any]
-        let frameDuration = if let unclampedDelayTime = frameProperty?[kCGImagePropertyWebPUnclampedDelayTime] as? Double {
-            unclampedDelayTime
-        } else if let delayTime = frameProperty?[kCGImagePropertyWebPDelayTime] as? Double {
-            delayTime
-        } else {
-            0.1
-        }
-        if frameDuration < 0.011 {
-            return 0.1
-        }
-        return frameDuration
+        let frameDurationProcessor = FrameDurationProcessor()
+        let delayTime = frameDurationProcessor.process(
+            unclampedDelayTime: { frameProperty?[kCGImagePropertyWebPUnclampedDelayTime] as? Double },
+            delayTime: { frameProperty?[kCGImagePropertyWebPDelayTime] as? Double }
+        )
+        return delayTime
     }
 
     public nonisolated func image(at index: Int) -> CGImage? {

--- a/Sources/AnimatedImageCore/Processors/FrameDurationProcessor.swift
+++ b/Sources/AnimatedImageCore/Processors/FrameDurationProcessor.swift
@@ -1,0 +1,25 @@
+
+struct FrameDurationProcessor: Sendable {
+    
+    let defaultDelayTime: Double = 0.1
+    let minimumDelayTime: Double = 0.011 // 10ms
+    
+    func process(
+        unclampedDelayTime: () -> Double?,
+        delayTime: () -> Double?
+    ) -> Double {
+        let result: Double
+        if let unclampedDelayTime = unclampedDelayTime() {
+            result = unclampedDelayTime
+        } else if let delayTime = delayTime() {
+            result = delayTime
+        } else {
+            result = defaultDelayTime
+        }
+        // http://webkit.org/b/36082
+        if result < minimumDelayTime {
+            return defaultDelayTime
+        }
+        return result
+    }
+}

--- a/Tests/AnimatedImageTests/Processors/FrameDurationProcessorTests.swift
+++ b/Tests/AnimatedImageTests/Processors/FrameDurationProcessorTests.swift
@@ -1,0 +1,67 @@
+import Testing
+
+@testable import AnimatedImageCore
+
+@Suite("FrameDurationProcessor テスト")
+struct FrameDurationProcessorTests {
+
+    @Test("unclampedDelayTime を優先して利用する")
+    func usesUnclampedDelayWhenAvailable() {
+        let processor = FrameDurationProcessor()
+
+        let result = processor.process(
+            unclampedDelayTime: { 0.2 },
+            delayTime: { 0.05 }
+        )
+
+        #expect(result == 0.2)
+    }
+
+    @Test("delayTime は unclampedDelayTime が nil のときに使用される")
+    func fallsBackToDelayTime() {
+        let processor = FrameDurationProcessor()
+
+        let result = processor.process(
+            unclampedDelayTime: { nil },
+            delayTime: { 0.15 }
+        )
+
+        #expect(result == 0.15)
+    }
+
+    @Test("両方の遅延が nil のときにデフォルト値を返す")
+    func returnsDefaultDelayWhenBothValuesNil() {
+        let processor = FrameDurationProcessor()
+
+        let result = processor.process(
+            unclampedDelayTime: { nil },
+            delayTime: { nil }
+        )
+
+        #expect(result == processor.defaultDelayTime)
+    }
+
+    @Test("最小遅延よりも短い値はデフォルト遅延に丸められる")
+    func enforcesMinimumDelayThreshold() {
+        let processor = FrameDurationProcessor()
+
+        let result = processor.process(
+            unclampedDelayTime: { processor.minimumDelayTime / 2 },
+            delayTime: { nil }
+        )
+
+        #expect(result == processor.defaultDelayTime)
+    }
+
+    @Test("最小遅延丁度の値はそのまま採用される")
+    func acceptsMinimumDelay() {
+        let processor = FrameDurationProcessor()
+
+        let result = processor.process(
+            unclampedDelayTime: { processor.minimumDelayTime },
+            delayTime: { nil }
+        )
+
+        #expect(result == processor.minimumDelayTime)
+    }
+}


### PR DESCRIPTION
Introduced FrameDurationProcessor to centralize and standardize frame delay time extraction and clamping logic for APNG, GIF, and WebP images. Updated image classes to use this processor, ensuring consistent handling of minimum and default delay times. Added comprehensive tests for FrameDurationProcessor.
