### PR TITLE
Fix flickering when setting image due to premature contents clear (closes #28)

### DIFF
--- a/Sources/_UIKit_AnimatedImage/AnimatedImageView.swift
+++ b/Sources/_UIKit_AnimatedImage/AnimatedImageView.swift
@@ -21,8 +21,6 @@ open class AnimatedImageView: AnimatableCGImageView {
 
     private var provider: AnimatedImageProvider? = nil {
         didSet {
-            contents = nil
-
             if let image {
                 provider?
                     .update(for: bounds.size, scale: traitCollection.displayScale, image: image)


### PR DESCRIPTION
This change addresses the flickering issue described in https://github.com/noppefoxwolf/AnimatedImage/issues/28.

When a new image is assigned to `AnimatedImageView`, the view’s underlying layer contents were being cleared (`contents = nil`) before the next frame was ready to render. In certain use cases—such as when using `AnimatedImageView` inside a paging / swipe-based layout in SwiftUI—this caused a brief blank frame to appear, perceived as a visible flicker during redraw.

The following video shows the behavior **after** this change has been applied, clearly illustrating that the flicker described in Issue #28 is no longer present.

https://github.com/user-attachments/assets/8f64dcde-e761-43b2-b226-334ae3b24274