### PR TITLE
画像差し替え後に画像が表示されなくなる問題を修正

### DIFF
--- a/Sources/_UIKit_AnimatedImage/AnimatedImageView.swift
+++ b/Sources/_UIKit_AnimatedImage/AnimatedImageView.swift
@@ -27,6 +27,7 @@ open class AnimatedImageView: AnimatableCGImageView {
 
     private var decodedImage: AnimatedImage? = nil {
         didSet {
+            currentFrameIndex = nil
             setNeedsDisplay()
         }
     }


### PR DESCRIPTION
## 問題

`AnimatedImagePlayer` を `ScrollView` + Lazy系 のView内で使用すると、スクロールを行ったり来たりした際に1フレームの gifなどの一部gif表示されなくなり、復帰しないことがありました

## 原因

画像の差し替え時に `AnimatedImageView.currentFrameIndex` がリセットされていない

発生シーケンス:

1. gif が表示され、`currentFrameIndex` が `0` になる
2. SwiftUI が body を再評価し、`updateUIView` が新しい `AnimatedImage` インスタンスを代入する。`willSet` で `contents` と `decodedImage` はクリアされるが、`currentFrameIndex` には古い値が残る
3. 新しいデコードが完了した後、`contentsForTimestamp` は新しいフレームインデックスを古い `currentFrameIndex` と比較
    ```swift
    guard let index, currentFrameIndex != index else { return nil }
    ```

indices がユニークなインデックスを1つしか持たないgif では、index が常に古い currentFrameIndex と一致して、このガードが毎 tick nil を返し続け、contents が設定されず表示されなくなってしまっている

## 修正内容

decodedImage の didSet で currentFrameIndex をリセットするよう修正しました。差し替え後の最初の更新 tick で必ず再描画されるようにしました

（issue前のPRになってしまいすみません）
