### PR TITLE
[codex] Fix NSCache wrapped key lookup

### DIFF
--- a/Sources/AnimatedImageCore/Utilities/Cache.swift
+++ b/Sources/AnimatedImageCore/Utilities/Cache.swift
@@ -44,21 +44,20 @@ nonisolated package final class Cache<Key: Hashable, Value>: @unchecked Sendable
 
 //Our WrappedKey type will, wrap our Key values in order to make them NSCache compatible
 extension Cache {
-    fileprivate nonisolated final class WrappedKey: Hashable {
+    fileprivate nonisolated final class WrappedKey: NSObject {
         let key: Key
 
         init(_ key: Key) {
             self.key = key
         }
 
-        func hash(into hasher: inout Hasher) {
-            hasher.combine(key)
+        override var hash: Int {
+            key.hashValue
         }
 
-        static func == (lhs: Cache<Key, Value>.WrappedKey, rhs: Cache<Key, Value>.WrappedKey)
-            -> Bool
-        {
-            lhs.key == rhs.key
+        override func isEqual(_ object: Any?) -> Bool {
+            guard let other = object as? WrappedKey else { return false }
+            return key == other.key
         }
     }
 

--- a/Tests/AnimatedImageTests/Utilities/AnimatedImageStateTests.swift
+++ b/Tests/AnimatedImageTests/Utilities/AnimatedImageStateTests.swift
@@ -35,6 +35,20 @@ struct AnimatedImageStateTests {
         #expect(longTimeIndex == 50)
     }
 
+    @Test("保存した画像を取得できる")
+    func storedImageCanBeRetrieved() {
+        let image = makeImage()
+        let state = AnimatedImageState(
+            name: "TestState",
+            size: Size(width: 10, height: 10),
+            indices: [0],
+            images: [0: image],
+            totalCostLimit: 1024 * 1024
+        )
+
+        #expect(state.image(at: 0) === image)
+    }
+
     private func makeState(indices: [Int], delayTime: TimeInterval) -> AnimatedImageState {
         AnimatedImageState(
             name: "TestState",
@@ -44,5 +58,18 @@ struct AnimatedImageStateTests {
             images: [:],
             totalCostLimit: 1024 * 1024
         )
+    }
+
+    private func makeImage() -> CGImage {
+        let context = CGContext(
+            data: nil,
+            width: 10,
+            height: 10,
+            bitsPerComponent: 8,
+            bytesPerRow: 10 * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )!
+        return context.makeImage()!
     }
 }


### PR DESCRIPTION
## Summary
- Fix Cache.WrappedKey to subclass NSObject and implement NSCache-compatible hash/equality
- Add a regression test that verifies AnimatedImageState can retrieve an inserted CGImage

## Root cause
NSCache uses NSObject-style key equality. The previous WrappedKey only conformed to Swift Hashable, so lookups with a newly wrapped equivalent key could miss immediately after insertion. Decoded frame images were produced, but AnimatedImageState.image(at:) returned nil, leaving players blank.

## Validation
- swift build
- Manual Playground check confirmed images render after the cache key fix

## Notes
- swift test --filter AnimatedImageState currently fails during test target compilation because existing CGSizeTests call Size.isLessThanOrEqual(to:) across actor isolation. That failure is unrelated to this change.